### PR TITLE
fix syntax of equality test in /bin/sh

### DIFF
--- a/scripts/shield-trigger-iptables
+++ b/scripts/shield-trigger-iptables
@@ -34,7 +34,7 @@ run_iptables() {
 	fi
 
 #	switch -A for iptables to -I
-	if [ "$1" == "-A" ]
+	if [ "$1" = "-A" ]
 	then
 		TASK="-I"
 	else
@@ -42,7 +42,7 @@ run_iptables() {
 	fi
 
 #	check to see if pam_shield chain exists and create if necessary
-	if [ "$TASK" == "-I" ]
+	if [ "$TASK" = "-I" ]
 	then
 		CHAIN_TEST=`$IPT -L pam_shield 2>/dev/null`
 		if [ -z "$CHAIN_TEST" ]


### PR DESCRIPTION
Teus Hagen wrote me an e-mail saying:
```
The script shield-trigger-iptables is using the sh (an falls down in some distros like Debian into the dash) engine.
In dump sh the test function will fail on arguments starting with the '-' symbol.
Maybe change "#! /bin/sh" to "#!/bin/bash" ?

To test it:
sh -c "[ -D == -D ]"

The failure message:

/usr/sbin/shield-trigger-iptables: 37: [: -D: unexpected operator
/usr/sbin/shield-trigger-iptables: 45: [: -D: unexpected operator
iptables v1.4.18: Couldn't load target `pam_shield':No such file or directory
```

The fix is to use a single `=` rather than `==` since this is for `/bin/sh`.

Greets,

    --Walter
